### PR TITLE
Fix fluid assets grid

### DIFF
--- a/src/components/Layout.scss
+++ b/src/components/Layout.scss
@@ -6,6 +6,7 @@
     width: 100%;
     margin-left: auto;
     margin-right: auto;
+    flex: 1 1;
 }
 
 .layout__sidebar {

--- a/src/components/asset/Asset.scss
+++ b/src/components/asset/Asset.scss
@@ -67,9 +67,7 @@
     width: auto;
     margin: auto;
     max-height: 10rem;
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
+    max-width: 100%;
     margin-bottom: $spacer / 2;
 }
 

--- a/src/components/asset/AssetFull.scss
+++ b/src/components/asset/AssetFull.scss
@@ -3,11 +3,6 @@
 .assetfull {
     margin: auto;
     max-width: $break-point--small;
-    overflow-wrap: break-word;
-    word-wrap: break-word;
-    -ms-word-break: break-all;
-    word-break: break-all;
-    word-break: break-word;
 
     .asset__img {
         max-height: none;

--- a/src/components/asset/AssetList.scss
+++ b/src/components/asset/AssetList.scss
@@ -1,30 +1,19 @@
 @import 'variables';
 
 .assets {
-    @media (min-width: $break-point--medium) {
-        display: flex;
-        flex-wrap: wrap;
-        margin-left: -($spacer);
-    }
-
-    @media (min-width: $break-point--large) {
-        display: flex;
-        flex-wrap: wrap;
+    @media (min-width: $break-point--small) {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+        margin: -($spacer / 2);
     }
 }
 
 .assets__tile {
-    margin-bottom: $spacer / 2;
+    margin-bottom: $spacer;
     height: 100%;
     outline: 0;
 
-    @media (min-width: $break-point--medium) {
-        flex: 1 1 calc(50% - #{$spacer * 2});
-        margin-left: $spacer;
-        max-width: 20rem;
-    }
-
-    @media (min-width: $break-point--large) {
-        flex: 1 1 33%;
+    @media (min-width: $break-point--small) {
+        margin: $spacer / 2;
     }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -32,6 +32,11 @@ body {
     color: $brand-grey;
     height: 100%;
     min-height: 100vh;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    -ms-word-break: break-all;
+    word-break: break-all;
+    word-break: break-word;
 
     @media screen and (min-width: $break-point--small) {
         display: flex;


### PR DESCRIPTION
It's perfectly fluid now no matter what content you throw at it:

![untitled](https://user-images.githubusercontent.com/90316/44216417-2c395300-a175-11e8-99cf-9cbed0c548f3.gif)
