### PR TITLE
use double quotes for expressions

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-envsubst '${KEEPER_SCHEME} ${KEEPER_HOST} ${KEEPER_PORT} ${OCEAN_SCHEME} ${OCEAN_HOST} ${OCEAN_PORT}'\
+envsubst "${KEEPER_SCHEME} ${KEEPER_HOST} ${KEEPER_PORT} ${OCEAN_SCHEME} ${OCEAN_HOST} ${OCEAN_PORT}"\
   < /pleuston/config/config.js.template > /pleuston/config/config.js
 sleep 30
 npm run build
-serve -l tcp://${LISTEN_ADDRESS}:${LISTEN_PORT} -s /pleuston/build/
+serve -l tcp://"${LISTEN_ADDRESS}":"${LISTEN_PORT}" -s /pleuston/build/


### PR DESCRIPTION
Fixing the "Expressions don't expand in single quotes, use double quotes for that" warning in Codacy, and "Double quote to prevent globbing and word splitting" from shellcheck