### PR TITLE
Fixed building process inside Docker image

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+  - scripts/docker-entrypoint.sh

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,3 +1,0 @@
----
-exclude_paths:
-  - scripts/docker-entrypoint.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,6 @@ node_modules
 .git
 .editorconfig
 .eslintignore
-.eslintrc
 .gitignore
 .stylelintrc
 .travis.yml
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /pleuston
 
 RUN npm install -g npm serve
 RUN npm install
-RUN chmod +x /pleuston/scripts/docker-entrypoint.sh
 
 # Default ENV values
 # config/config.js

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-envsubst '${KEEPER_SCHEME} ${KEEPER_HOST} ${KEEPER_PORT} ${OCEAN_SCHEME} ${OCEAN_HOST} ${OCEAN_PORT}'\
-  < /pleuston/config/config.js.template > /pleuston/config/config.js
+envsubst < /pleuston/config/config.js.template > /pleuston/config/config.js
 echo "Starting Pleuston..."
 npm run build
 serve -l tcp://"${LISTEN_ADDRESS}":"${LISTEN_PORT}" -s /pleuston/build/

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-envsubst "${KEEPER_SCHEME} ${KEEPER_HOST} ${KEEPER_PORT} ${OCEAN_SCHEME} ${OCEAN_HOST} ${OCEAN_PORT}"\
+envsubst '${KEEPER_SCHEME} ${KEEPER_HOST} ${KEEPER_PORT} ${OCEAN_SCHEME} ${OCEAN_HOST} ${OCEAN_PORT}'\
   < /pleuston/config/config.js.template > /pleuston/config/config.js
-sleep 30
+echo "Starting Pleuston..."
 npm run build
 serve -l tcp://"${LISTEN_ADDRESS}":"${LISTEN_PORT}" -s /pleuston/build/


### PR DESCRIPTION
## Description

Fixes the `npm run build` inside the Docker image. The problem was ignoring the file `.eslintrc` inside the docker image.

## Is this PR related with an open issue?

Related to Issue #97 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
