### PR TITLE
Added back the sleep in docker-entrypoint.sh

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 envsubst < /pleuston/config/config.js.template > /pleuston/config/config.js
+echo "Waiting for keeper-contracts ${KEEPER_CONTRACTS_WAIT_SLEEP:-60} seconds..."
+sleep ${KEEPER_CONTRACTS_WAIT_SLEEP:-60}
 echo "Starting Pleuston..."
 npm run build
 serve -l tcp://"${LISTEN_ADDRESS}":"${LISTEN_PORT}" -s /pleuston/build/


### PR DESCRIPTION
## Description

Add a configurable sleep time (default 60 seconds) before pleuston compilation.

## Is this PR related with an open issue?

No

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()