### PR TITLE
Wait for flag from keeper-contracts when contracts are ready

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 envsubst < /pleuston/config/config.js.template > /pleuston/config/config.js
-echo "Waiting for keeper-contracts ${KEEPER_CONTRACTS_WAIT_SLEEP:-60} seconds..."
-sleep ${KEEPER_CONTRACTS_WAIT_SLEEP:-60}
+echo "Waiting for contracts to be generated..."
+while [ ! -f "/pleuston/node_modules/@oceanprotocol/keeper-contracts/artifacts/ready" ]; do
+  sleep 2
+done
 echo "Starting Pleuston..."
 npm run build
 serve -l tcp://"${LISTEN_ADDRESS}":"${LISTEN_PORT}" -s /pleuston/build/


### PR DESCRIPTION
## Description

Check if a flag file exists and the start loading pleuston. Removes sleep.

## Is this PR related with an open issue?

Related to Issue oceanprotocol/docker-images#23, oceanprotocol/keeper-contracts#105 and oceanprotocol/provider#62.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation