### PR TITLE
New variable to enable waiting for contracts

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
 envsubst < /pleuston/config/config.js.template > /pleuston/config/config.js
-echo "Waiting for contracts to be generated..."
-while [ ! -f "/pleuston/node_modules/@oceanprotocol/keeper-contracts/artifacts/ready" ]; do
-  sleep 2
-done
+if [ "${LOCAL_CONTRACTS}" = "true" ]; then
+  echo "Waiting for contracts to be generated..."
+  while [ ! -f "/pleuston/node_modules/@oceanprotocol/keeper-contracts/artifacts/ready" ]; do
+    sleep 2
+  done
+fi
 echo "Starting Pleuston..."
 npm run build
 serve -l tcp://"${LISTEN_ADDRESS}":"${LISTEN_PORT}" -s /pleuston/build/


### PR DESCRIPTION
## Description

Included the variable `$LOCAL_CONTRACTS`. If it is equal to "true", it will wait for the file `/usr/local/keeper-contracts/ready` to exists before starting. In other case it will start directly.

## Is this PR related with an open issue?

Related to Issue oceanprotocol/docker-images#25

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()