### PR TITLE
Add type attribute 

### DIFF
--- a/src/actions/asset.js
+++ b/src/actions/asset.js
@@ -24,6 +24,7 @@ export async function publish(formValues, account, providers) {
         copyrightHolder,
         tags,
         price,
+        type,
         updateFrequency
     } = formValues
 
@@ -55,7 +56,8 @@ export async function publish(formValues, account, providers) {
             // links: ,
             // inLanguage: ,
             tags: tags ? [tags.split(',')] : [],
-            price: parseFloat(price)
+            price: parseFloat(price),
+            type
         }),
         curation: Object.assign(AssetModel.curation, {
             rating: 0,

--- a/src/components/asset/AssetFull.js
+++ b/src/components/asset/AssetFull.js
@@ -55,6 +55,7 @@ class AssetFull extends PureComponent {
             dateCreated,
             // size,
             author,
+            type,
             license,
             copyrightHolder,
             // encoding,
@@ -111,6 +112,8 @@ class AssetFull extends PureComponent {
                     <AssetFullMeta label="Tags" item={tags.map(tag => (tag))} />
                 )}
 
+                <AssetFullMeta label="Type" item={type} />
+
                 <AssetFullMeta label="License" item={license} />
 
                 {additionalInformation.updateFrequency && (
@@ -139,6 +142,7 @@ AssetFull.propTypes = {
         dateCreated: PropTypes.date,
         // size: PropTypes.string.isRequired,
         author: PropTypes.string.isRequired,
+        type: PropTypes.string.isRequired,
         license: PropTypes.string.isRequired,
         copyrightHolder: PropTypes.string,
         // encoding: PropTypes.string,

--- a/src/components/asset/AssetNew.js
+++ b/src/components/asset/AssetNew.js
@@ -11,24 +11,35 @@ const AssetNew = ({
     <form className="form" onSubmit={handleSubmit}>
         <div className="form__group">
             <FormInput label="Title" name="name" required component="input" type="text" placeholder="" />
-            <FormHelp>The title of your data set.</FormHelp>
+            <FormHelp>The title of your asset.</FormHelp>
         </div>
         <div className="form__group">
             <FormInput label="Description" name="description" required component="textarea" rows="5" placeholder="" />
-            <FormHelp>Describe your data set, explaining what the data represents and what it can be used for.</FormHelp>
+            <FormHelp>Describe your asset, explaining what the data represents and what it can be used for.</FormHelp>
         </div>
         <div className="form__group">
             <FormInput label="Url" name="contentUrls" required component="input" type="url" placeholder="e.g. https://url.com/dataset.zip" />
-            <FormHelp>Add a URL pointing to your data set asset.</FormHelp>
+            <FormHelp>Add a URL pointing to your asset.</FormHelp>
         </div>
         <div className="form__group">
             <FormInput label="Price" name="price" required type="number" component="input" placeholder="0" />
-            <FormHelp>Price of your data set asset in Ocean Tokens.</FormHelp>
+            <FormHelp>Price of your asset in Ocean Tokens.</FormHelp>
         </div>
 
         <div className="form__group">
             <FormInput label="Author" name="author" required component="input" type="text" placeholder="e.g. Tfl, Disney Corp." />
             <FormHelp>The name of the entity generating this data.</FormHelp>
+        </div>
+        <div className="form__group">
+            <FormInput label="Type" required name="type" component="select">
+                <option />
+                <option value="dataset">Data set</option>
+                <option value="algorithm">Algorithm</option>
+                <option value="container">Container</option>
+                <option value="workflow">Workflow</option>
+                <option value="other">Other</option>
+            </FormInput>
+            <FormHelp>The type of your asset.</FormHelp>
         </div>
         <div className="form__group">
             <FormInput label="License" required name="license" component="select">
@@ -49,7 +60,7 @@ const AssetNew = ({
 
         <div className="form__group">
             <FormInput label="Tags" name="tags" component="input" placeholder="e.g. climate, ocean, atmosphere, temperature, earth-science, public" />
-            <FormHelp>Categorize your data set by one or more tags, separated by comma.</FormHelp>
+            <FormHelp>Categorize your asset by one or more tags, separated by comma.</FormHelp>
         </div>
         <div className="form__group">
             <FormInput label="Update Frequency" name="updateFrequency" component="select">

--- a/src/mock/assets.js
+++ b/src/mock/assets.js
@@ -8,6 +8,7 @@ const mockAssets = [
             'size': '3.1gb',
             'dateCreated': '2012-02-01T10:55:11+00:00',
             'author': 'Met Office',
+            'type': 'dataset',
             'license': 'CC-BY',
             'copyrightHolder': 'Met Office',
             'encoding': 'UTF-8',

--- a/src/models/asset.js
+++ b/src/models/asset.js
@@ -10,6 +10,7 @@ const AssetModel = {
         'dateCreated': null,
         'size': null,
         'author': null,
+        'type': '',
         'license': null,
         'copyrightHolder': null,
         'encoding': null,

--- a/src/pages/NewDataset.js
+++ b/src/pages/NewDataset.js
@@ -6,7 +6,7 @@ import AssetNewLoader from '../containers/AssetNewLoader'
 
 const NewDataset = () => (
     <Layout narrow>
-        <ScreenHeader title="Publish" subtitle="Publish a new data set" />
+        <ScreenHeader title="Publish" subtitle="Publish a new asset" />
         <AssetNewLoader />
     </Layout>
 )


### PR DESCRIPTION
Adds a new attribute `type` to asset model. Asks for the attribute with a predefined `select` and outputs it in `AssetFull` view.

<img width="570" alt="screen shot 2018-09-25 at 10 42 51" src="https://user-images.githubusercontent.com/90316/46003001-c8794280-c0af-11e8-9029-8b1e602ba40f.png">

<img width="575" alt="screen shot 2018-09-25 at 10 42 56" src="https://user-images.githubusercontent.com/90316/46003009-cadb9c80-c0af-11e8-9929-a5b3b4ed283d.png">

* implementing https://github.com/oceanprotocol/OEPs/pull/76
* closes https://github.com/oceanprotocol/ocean/issues/173
* in sync with https://github.com/oceanprotocol/provider/pull/65
* filtering and actually using the attribute will be done as part of https://github.com/oceanprotocol/ocean/issues/119

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

#### Funny gif

![200w](https://user-images.githubusercontent.com/90316/46002917-949e1d00-c0af-11e8-87a1-48bdf7444dc1.gif)