### PR TITLE
fix bool warning

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -35,12 +35,16 @@ class Layout extends PureComponent {
             <Fragment>
                 <HeaderLoader />
 
-                <main className={styles.layout} {...this.props}>
+                <main className={styles.layout}>
                     <nav className={styles.layoutSidebar}>
                         <SidebarLoader />
                     </nav>
-                    {loading ? <Spinner />
-                        : this.props.narrow ? <div className={styles.narrow}>{this.props.children}</div> : this.props.children
+                    {
+                        loading
+                            ? <Spinner />
+                            : this.props.narrow
+                                ? <div className={styles.narrow}>{this.props.children}</div>
+                                : this.props.children
                     }
                 </main>
             </Fragment>
@@ -49,7 +53,8 @@ class Layout extends PureComponent {
 }
 
 Layout.propTypes = {
-    children: PropTypes.any.isRequired
+    children: PropTypes.any.isRequired,
+    narrow: PropTypes.bool
 }
 
 export default Layout


### PR DESCRIPTION
Component props for `Layout` were passed through onto a DOM element, making it a non-boolean attribute resulting in a React warning. Passing the props onto that element is not required so simply remove it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Funny gif

![giphy](https://user-images.githubusercontent.com/90316/46009412-c0c19a00-c0bf-11e8-8afe-16a77fa5118b.gif)