### PR TITLE
Fix/routing orders

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -11,9 +11,9 @@ const Routes = () => (
     <Switch>
         <Route exact component={Datasets} path="/" />
         <Route exact component={NewDataset} path="/new" />
-        <Route exact component={DatasetLoader} path="/:id" />
         <Route exact component={Orders} path="/orders" />
         <Route exact component={OrderLoader} path="/orders/:id" />
+        <Route exact component={DatasetLoader} path="/:id" />
 
         <Route component={NotFound} />
     </Switch>

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -115,7 +115,7 @@ export function getActiveAsset(state) {
     const { activeAsset, assets } = state.asset
 
     if (!activeAsset && state.router.location.pathname) {
-        const rgxAssetId = /\/datasets\/(.*?)/g
+        const rgxAssetId = /\/(.*?)/g
         const { pathname } = state.router.location
         if (rgxAssetId.exec(pathname)) {
             const assetIdFromUrl = pathname.replace(/^.*[\\\/]/, '') // eslint-disable-line
@@ -184,7 +184,7 @@ export function getOrders() {
         }
 
         const { ocean } = state.provider
-        let orders = await ocean.getOrdersByConsumer(account.name)
+        let orders = await Promise.all(await ocean.getOrdersByConsumer(account.name))
         Logger.log('ORDERS: ', orders, Object.values(state.asset.assets))
         let assets = null
         if (Object.values(state.asset.assets).length !== 0) {


### PR DESCRIPTION
## Description

- Moving routing for asset after everything else to unhide orders routes
- Fix for retrieving ocean.getOrdersByConsumer

## Is this PR related with an open issue?

No.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()