### PR TITLE
Split codacy-coverage to avoid running it locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - npm install
 
 script:
-- npm run test
+- npm run test:ci
 - npm run build
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ npm run lint
 
 ## Testing
 
-Automatic tests are setup via Travis, executing `npm test`.
+Automatic tests are setup via Travis, executing `npm test:ci`. If you want to execute these tests locally, please use `npm test`. Otherwise, setup an account with [Codacy](https://www.codacy.com/) and provide an API Token as described in their [documentation](https://support.codacy.com/hc/en-us/articles/115000255385).
 
 At the moment, besides linting tests, there's only one test checking if the whole app can be rendered.
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint:js": "eslint ./src/",
     "lint:css": "stylelint ./src/**/*.scss",
     "lint": "run-p --continue-on-error lint:js lint:css",
-    "test": "npm run lint && node scripts/test.js --env=jsdom --coverage && cat ./coverage/lcov.info",
-    "test:ci": "npm run test | codacy-coverage",
+    "test": "npm run lint && node scripts/test.js --env=jsdom --coverage",
+    "test:ci": "npm run test && cat ./coverage/lcov.info | codacy-coverage",
     "requirements-check": "./scripts/check-node-version.sh",
     "preinstall": "npm run requirements-check"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint:js": "eslint ./src/",
     "lint:css": "stylelint ./src/**/*.scss",
     "lint": "run-p --continue-on-error lint:js lint:css",
-    "test": "npm run lint && node scripts/test.js --env=jsdom --coverage && cat ./coverage/lcov.info | codacy-coverage",
+    "test": "npm run lint && node scripts/test.js --env=jsdom --coverage && cat ./coverage/lcov.info",
+    "test:ci": "npm run test | codacy-coverage",
     "requirements-check": "./scripts/check-node-version.sh",
     "preinstall": "npm run requirements-check"
   },


### PR DESCRIPTION
## Description

`npm run test` was running `codacy-coverage` which requires a token, pretty annoying for local testing. Thus, split task into two, so Travis can still submit coverage when needed.

## Is this PR related with an open issue?

Related to Issue #160 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [X] Follows the code style of this project.
- [X] Tests Cover Changes
- [X] Documentation

(Actually it's just a quick documentation update, and changes to how travis runs things compared to locally).

#### Funny gif
Me trying to look for actual code in Blockchain projects.
![Put a link of a funny gif inside the parenthesis-->](https://media.giphy.com/media/8ZeZFklbGo82Z72FHp/giphy.gif)