### PR TITLE
Travis secure env variables workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ install:
 - npm install
 
 script:
-- npm run test:ci
+- npm test
+- 'if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then npm run coverage; fi'
 - npm run build
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -23,19 +23,21 @@ Main issues right now:
 
 ## Table of Contents
 
-- [Features](#features)
-- [Prerequisites](#prerequisites)
-    - [🐋 aquarius](#aquarius)
-    - [💧 keeper-contracts](#keeper-contracts)
-- [Storage Providers](#storage-providers)
-    - [Azure Storage](#azure-storage)
-- [Development](#development)
-    - [MetaMask](#metamask)
-    - [Production build](#production-build)
-- [Configuration](#configuration)
-- [Code style](#code-style)
-- [Testing](#testing)
-- [License](#license)
+- [Pleuston](#pleuston)
+    - [Table of Contents](#table-of-contents)
+    - [Features](#features)
+    - [Prerequisites](#prerequisites)
+        - [🐋 aquarius](#-aquarius)
+        - [💧 keeper-contracts](#-keeper-contracts)
+    - [Storage Providers](#storage-providers)
+        - [Azure Storage](#azure-storage)
+    - [Development](#development)
+        - [MetaMask](#metamask)
+        - [Production build](#production-build)
+    - [Configuration](#configuration)
+    - [Testing](#testing)
+    - [Code style](#code-style)
+    - [License](#license)
 
 ---
 
@@ -149,21 +151,26 @@ module.exports = {
 }
 ```
 
+## Testing
+
+Automatic tests are setup via Travis, executing `npm test`.
+
+The tests run:
+
+- linting checks with ESLint and Stylelint
+- basic rendering tests for components with Jest
+
+While code coverage status will be reported in the console and on Travis, coverage information won't be uploaded to Codacy for any Pull Request from a forked repo. That is because of a [security restriction in Travis](https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions).
+
 ## Code style
 
 Code linting is setup with [ESLint](https://eslint.org) and [stylelint](https://stylelint.io) following [eslint-config-oceanprotocol](https://github.com/oceanprotocol/eslint-config-oceanprotocol) and [stylelint-config-bigchaindb](https://github.com/bigchaindb/stylelint-config-bigchaindb).
 
-There's a npm script setup which runs all linting tests:
+There's a npm script setup which runs only linting tests:
 
 ```bash
 npm run lint
 ```
-
-## Testing
-
-Automatic tests are setup via Travis, executing `npm test:ci`. If you want to execute these tests locally, please use `npm test`. Otherwise, setup an account with [Codacy](https://www.codacy.com/) and provide an API Token as described in their [documentation](https://support.codacy.com/hc/en-us/articles/115000255385).
-
-At the moment, besides linting tests, there's only one test checking if the whole app can be rendered.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:css": "stylelint ./src/**/*.scss",
     "lint": "run-p --continue-on-error lint:js lint:css",
     "test": "npm run lint && node scripts/test.js --env=jsdom --coverage",
-    "test:ci": "npm run test && cat ./coverage/lcov.info | codacy-coverage",
+    "coverage": "cat ./coverage/lcov.info | codacy-coverage",
     "requirements-check": "./scripts/check-node-version.sh",
     "preinstall": "npm run requirements-check"
   },


### PR DESCRIPTION
Workaround for Travis' secret environment variables not being exposed to forks. 

We only use secret environment variables for sending the code coverage results to Codacy which is not a super critical task. So this workaround should be enough to make contributor's lives easier until we figure out the proper solution as suggested by @jjperezaguinaga in https://github.com/oceanprotocol/pleuston/issues/159#issuecomment-435620906

* split up testing & Codacy coverage sending
* send coverage only when `TRAVIS_SECURE_ENV_VARS` variable is `true`. Since PRs from forks won't have access to secure variables, the Codacy coverage sending script won't run for them
* reduce to 1 test script again
* add note about all this to readme
* closes #159
* closes #160 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Funny gif

![giphy-1](https://user-images.githubusercontent.com/90316/48000089-ca014600-e104-11e8-8dc1-492ce6507aca.gif)