### PR TITLE
cloud actions: cross-window communication & logout

### DIFF
--- a/src/components/asset/CloudStorageActions.js
+++ b/src/components/asset/CloudStorageActions.js
@@ -74,6 +74,13 @@ export default class CloudStorageActions extends PureComponent {
         }
     }
 
+    clearOauthAccounts = () => {
+        if (typeof window !== 'undefined') {
+            window.localStorage.removeItem('oauthAccounts')
+        }
+        this.setState({ isConnected: false })
+    }
+
     render() {
         const { linkSetter } = this.props
 
@@ -87,15 +94,23 @@ export default class CloudStorageActions extends PureComponent {
                         args={{ response_type: 'token', scope }}
                         state={{ from: '/new' }}
                         render={({ url }) => (
-                            <Button
-                                link="true"
-                                icon={IconAzure}
-                                onClick={(e) => this.toggleAzure(e, url)}
-                            >
+                            <>
+                                <Button
+                                    link="true"
+                                    icon={IconAzure}
+                                    onClick={(e) => this.toggleAzure(e, url)}
+                                >
                                 Azure
-                            </Button>
-                            // TODO: add some feedback for connected state
-                            // TODO: add signout/disconnect action
+                                </Button>
+                                {this.state.isConnected && (
+                                    <Button
+                                        className={styles.logout}
+                                        onClick={this.clearOauthAccounts}
+                                    >
+                                    logout
+                                    </Button>
+                                )}
+                            </>
                         )}
                     />
                 </div>

--- a/src/components/asset/CloudStorageActions.js
+++ b/src/components/asset/CloudStorageActions.js
@@ -16,7 +16,30 @@ export default class CloudStorageActions extends PureComponent {
     }
 
     state = {
-        isModalOpen: false
+        isModalOpen: false,
+        isConnected: false
+    }
+
+    componentDidMount() {
+        if (typeof window !== 'undefined') {
+            this.setState({ isConnected: !!window.localStorage.getItem('oauthAccounts') })
+
+            window.addEventListener('storage', this.localStorageUpdated)
+        }
+    }
+
+    componentWillUnmount() {
+        if (typeof window !== 'undefined') {
+            window.removeEventListener('storage', this.localStorageUpdated)
+        }
+    }
+
+    localStorageUpdated = () => {
+        if (!window.localStorage.getItem('oauthAccounts')) {
+            this.setState({ isConnected: false })
+        } else if (!this.state.isConnected) {
+            this.setState({ isConnected: true })
+        }
     }
 
     toggleModal = () => {
@@ -43,9 +66,8 @@ export default class CloudStorageActions extends PureComponent {
         // https://stackoverflow.com/questions/43514537/maintain-redux-state-from-popup-to-main-window
         //
         // const isConnected = this.props.oauthAccounts.azure && this.props.oauthAccounts.azure.expires_on < Date.now()
-        const isConnected = window.localStorage.getItem('oauthAccounts') !== null
 
-        if (isConnected) {
+        if (this.state.isConnected) {
             this.toggleModal()
         } else {
             this.toggleOauthPopup(url)

--- a/src/components/asset/CloudStorageActions.module.scss
+++ b/src/components/asset/CloudStorageActions.module.scss
@@ -6,3 +6,15 @@
     border-top: 1px solid $brand-grey-lighter;
     padding-top: $spacer / 4;
 }
+
+.logout {
+    font-size: $font-size-mini;
+    display: inline-block;
+    margin-left: $spacer / 4;
+    color: $brand-grey-light;
+    background: none;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    cursor: pointer;
+}


### PR DESCRIPTION
Use `StorageEvent` to listen for `localStorage` changes effectively making cross-window communication possible, and allowing the `CloudStorageActions` component to adapt to localStorage changes.

* set local state `isConnected` based on `localStorage` values
* listen for `localStorage` changes, update local state accordingly
* now correctly detects successful connection after the initial OAuth popup is closed
* add logout action if user is connected, in turn giving feedback about connected state to user
* closes #145
* closes #143

## Caveats

Probably only works in Chrome & Firefox which is alright because only those browsers also support MetaMask.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

#### Funny gif

OAuth popup window is all like:

![giphy](https://user-images.githubusercontent.com/90316/48063649-ff219d00-e1c5-11e8-8c65-b07207030561.gif)