### PR TITLE
Added variables to be able to configure docker deployments

### DIFF
--- a/config/ocean.js.template
+++ b/config/ocean.js.template
@@ -1,0 +1,12 @@
+module.exports = {
+    // -----
+    // Setup with local services
+    // -----
+    keeperScheme: '${KEEPER_SCHEME}',
+    keeperHost: '${KEEPER_HOST}',
+    keeperPort: ${KEEPER_PORT},
+
+    aquariusScheme: '${AQUARIUS_SCHEME}',
+    aquariusHost: '${AQUARIUS_HOST}',
+    aquariusPort: ${AQUARIUS_PORT}
+}

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 
-envsubst < /pleuston/config/config.js.template > /pleuston/config/config.js
+KEEPER_SCHEME=${KEEPER_SCHEME:-http}
+KEEPER_HOST=${KEEPER_HOST:-localhost}
+KEEPER_PORT=${KEEPER_PORT:-8545}
+AQUARIUS_SCHEME=${AQUARIUS_SCHEME:-http}
+AQUARIUS_HOST=${AQUARIUS_HOST:-localhost}
+AQUARIUS_PORT=${AQUARIUS_PORT:-5000}
+
+envsubst < /pleuston/config/ocean.js.template > /pleuston/config/ocean.js
 if [ "${LOCAL_CONTRACTS}" = "true" ]; then
   echo "Waiting for contracts to be generated..."
   while [ ! -f "/pleuston/node_modules/@oceanprotocol/keeper-contracts/artifacts/ready" ]; do


### PR DESCRIPTION
## Description

Currently the connection endpoints for keeper and aquarius are hardcoded in the configuration. With this change we can pass some variables to the docker image to modify those parameters.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()