### PR TITLE
metadata updates

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,19 +6,19 @@
   },
   "dependencies": [{
       "name": "keeper-contracts",
-      "version": "~0.9.1"
+      "version": "~0.9.7"
     },
     {
       "name": "brizo",
-      "version": "~0.3.5"
+      "version": "~0.3.8"
     },
     {
       "name": "aquarius",
-      "version": "~0.2.2"
+      "version": "~0.2.8"
     },
     {
       "name": "squid-js",
-      "version": "~0.5.6"
+      "version": "~0.5.14"
     }
   ]
 }

--- a/src/actions/asset.js
+++ b/src/actions/asset.js
@@ -70,7 +70,7 @@ export async function list(state) {
         offset: 100,
         page: state.asset.search.page,
         sort: {
-            text: 1
+            created: -1
         },
         query: {}
     }

--- a/src/actions/asset.js
+++ b/src/actions/asset.js
@@ -4,6 +4,7 @@ import * as Web3 from 'web3'
 
 export async function publish(formValues, account, providers) {
     const { ocean } = providers
+
     // Get user entered form values
     const {
         name,
@@ -18,14 +19,17 @@ export async function publish(formValues, account, providers) {
         type,
         updateFrequency
     } = formValues
-    // Now register in oceandb and publish the metadata
+
+    // Now register and publish the metadata
     const newAsset = {
         // OEP-08 Attributes
         // https://github.com/oceanprotocol/OEPs/tree/master/8
         base: Object.assign(AssetModel.base, {
             name,
             description,
-            dateCreated: (new Date()).toString(),
+            dateCreated: new Date()
+                .toISOString()
+                .split('.')[0] + 'Z', // remove milliseconds
             author,
             license,
             copyrightHolder,
@@ -34,36 +38,26 @@ export async function publish(formValues, account, providers) {
                 url: files
             }],
             links: links,
-            tags: tags,
-            price: Web3.utils.toWei(price, 'ether'),
+            tags: tags && tags.split(','),
+            price: Web3.utils.toWei(price, 'ether'), // convert to vodka 10^18
             type
-        }),
-        curation: Object.assign(AssetModel.curation, {
-            rating: 0,
-            numVotes: 0,
-            schema: 'Binary Voting'
         }),
         additionalInformation: Object.assign(AssetModel.additionalInformation, {
             updateFrequency
         })
     }
     try {
-        const asset = await ocean.assets.create(
-            newAsset,
-            account
-        )
+        const asset = await ocean.assets.create(newAsset, account)
         Logger.debug('asset: ', asset)
         return asset
-    } catch (e) {
-        // make readable errors
-        Logger.log('error:', e)
+    } catch (error) {
+        Logger.error('error:', error.message)
     }
 }
 
 export async function list(state) {
-    const {
-        ocean
-    } = state.provider
+    const { ocean } = state.provider
+
     let searchForm
     if (state.form && state.form.assetSearch && state.form.assetSearch.values) {
         searchForm = state.form.assetSearch.values
@@ -73,7 +67,7 @@ export async function list(state) {
         }
     }
     let queryRequest = {
-        offset: 500,
+        offset: 100,
         page: state.asset.search.page,
         sort: {
             text: 1
@@ -115,6 +109,7 @@ export async function list(state) {
 
 export async function purchase(inputDdo, consumer, providers) {
     const { ocean } = providers
+
     try {
         const accessService = inputDdo.findServiceByType('Access')
         const agreementId = await ocean.assets.order(
@@ -125,7 +120,7 @@ export async function purchase(inputDdo, consumer, providers) {
         const folder = ''
         const path = await ocean.assets.consume(agreementId, inputDdo.id, accessService.serviceDefinitionId, consumer, folder)
         Logger.log('path', path)
-    } catch (e) {
-        Logger.log('error', e)
+    } catch (error) {
+        Logger.error('error', error.message)
     }
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -70,8 +70,8 @@ export function makeItRain(amount) {
                 getActiveAccount(state).id
             )
             dispatch(getAccounts())
-        } catch (e) {
-            Logger.error(e)
+        } catch (error) {
+            Logger.error(error.message)
         }
     }
 }

--- a/src/actions/ocean.js
+++ b/src/actions/ocean.js
@@ -1,6 +1,4 @@
-import {
-    Ocean
-} from '@oceanprotocol/squid'
+import { Ocean } from '@oceanprotocol/squid'
 
 import {
     nodeScheme,

--- a/src/components/asset/AssetFull.js
+++ b/src/components/asset/AssetFull.js
@@ -9,17 +9,6 @@ import * as Web3 from 'web3'
 import Button from '../atoms/Button'
 import styles from './AssetFull.module.scss'
 
-// const Editable = ({ name, value, onFieldChange, onValueChange }) => (
-//     <input name={name} type="text" value={value} onChange={onValueChange} />
-// )
-
-// Editable.propTypes = {
-//     name: PropTypes.string,
-//     value: PropTypes.string,
-//     onFieldChange: PropTypes.func,
-//     onValueChange: PropTypes.func
-// }
-
 class AssetFull extends PureComponent {
     constructor(props) {
         super(props)
@@ -29,41 +18,26 @@ class AssetFull extends PureComponent {
         }
     }
 
-    onEdit(e) {
-        this.setState({
-            [e.target.name]: e.target.value
-        })
-    }
-
     render() {
-        const {
-            asset,
-            handlePurchase
-        } = this.props
+        const { asset, handlePurchase } = this.props
         if (!asset) return null
+
         const metadata = asset.findServiceByType('Metadata')
         const {
             base,
-            // curation,
             additionalInformation
         } = metadata.metadata
+
         // OEP-08 Base Attributes
         const {
             name,
             description,
             dateCreated,
-            // size,
             author,
             type,
             license,
             copyrightHolder,
-            // encoding,
-            // compression,
-            // contentType,
-            // workExample,
-            // files,
             links,
-            // inLanguage,
             tags,
             price
         } = base
@@ -93,17 +67,16 @@ class AssetFull extends PureComponent {
                 {links && links.length > 0 && <AssetFullMeta label="Links" links={links} />}
 
                 <AssetFullMeta label="Price" item={`${Web3.utils.fromWei(price.toString())} Ọ`} />
-                {/* <AssetFullMeta label="Token" item={token || 'Please purchase'} /> */}
 
                 {tags && tags.length > 0 && (
-                    <AssetFullMeta label="Tags" item={tags.split(',').map(tag => (tag))} />
+                    <AssetFullMeta label="Tags" item={tags.map(tag => tag)} />
                 )}
 
                 <AssetFullMeta label="Type" item={type} />
 
                 <AssetFullMeta label="License" item={license} />
 
-                {additionalInformation.updateFrequency && (
+                {additionalInformation && additionalInformation.updateFrequency && (
                     <AssetFullMeta label="Update Frequency" item={additionalInformation.updateFrequency} />
                 )}
 

--- a/src/components/asset/AssetFull.js
+++ b/src/components/asset/AssetFull.js
@@ -9,13 +9,10 @@ import * as Web3 from 'web3'
 import Button from '../atoms/Button'
 import styles from './AssetFull.module.scss'
 
-class AssetFull extends PureComponent {
-    constructor(props) {
-        super(props)
-
-        this.state = {
-            isWritable: false
-        }
+export default class AssetFull extends PureComponent {
+    static propTypes = {
+        handlePurchase: PropTypes.func,
+        asset: PropTypes.object
     }
 
     render() {
@@ -45,6 +42,7 @@ class AssetFull extends PureComponent {
         return (
             <div className={styles.assetFull}>
                 <h1 className={styles.assetFullTitle}>{name}</h1>
+                <h2 className={styles.did}>{asset.id}</h2>
 
                 {links && links.length && (
                     <p>
@@ -60,8 +58,6 @@ class AssetFull extends PureComponent {
 
                 <AssetFullMeta label="Published" item={dateCreated} />
 
-                <AssetFullMeta label="ID" item={asset.id} truncate />
-
                 {description && <AssetFullMeta label="Description" item={description} />}
 
                 {links && links.length > 0 && <AssetFullMeta label="Links" links={links} />}
@@ -69,7 +65,7 @@ class AssetFull extends PureComponent {
                 <AssetFullMeta label="Price" item={`${Web3.utils.fromWei(price.toString())} Ọ`} />
 
                 {tags && tags.length > 0 && (
-                    <AssetFullMeta label="Tags" item={tags.map(tag => tag)} />
+                    <AssetFullMeta label="Tags" item={tags.map(tag => <span key={tag} className={styles.tag}>{tag}</span>)} />
                 )}
 
                 <AssetFullMeta label="Type" item={type} />
@@ -87,10 +83,3 @@ class AssetFull extends PureComponent {
         )
     }
 }
-
-AssetFull.propTypes = {
-    handlePurchase: PropTypes.func,
-    asset: PropTypes.object
-}
-
-export default AssetFull

--- a/src/components/asset/AssetFull.module.scss
+++ b/src/components/asset/AssetFull.module.scss
@@ -7,11 +7,31 @@
 }
 
 .assetFullTitle {
-    font-size: $font-size-h3;
+    font-size: $font-size-h2;
     margin-top: $spacer;
-    margin-bottom: $spacer;
+    margin-bottom: $spacer / 4;
+}
+
+.did {
+    margin-top: 0;
+    font-size: $font-size-base;
+    color: $brand-grey-light;
+    word-break: break-all;
 }
 
 .assetFullActions {
     margin-top: $spacer;
+}
+
+.tag {
+    margin-left: $spacer / 3;
+
+    &:first-child {
+        margin-left: 0;
+    }
+
+    &:before {
+        content: '#';
+        color: $brand-grey-light;
+    }
 }

--- a/src/components/asset/New/CloudStorage/Picker.js
+++ b/src/components/asset/New/CloudStorage/Picker.js
@@ -8,7 +8,7 @@ import styles from './Picker.module.scss'
 export default class CloudStoragePicker extends PureComponent {
     _isMounted = false
     static propTypes = {
-        linkSetter: PropTypes.func.isRequired,
+        fileSetter: PropTypes.func.isRequired,
         handleCloseModal: PropTypes.func.isRequired,
         storageProvider: PropTypes.any.isRequired
     }
@@ -50,7 +50,7 @@ export default class CloudStoragePicker extends PureComponent {
         }
         const firstBlob = selectionWithData[0] // only first one from selected
         const link = await this.props.storageProvider.getSharableLink(firstBlob)
-        this.props.linkSetter(link)
+        this.props.fileSetter(link)
         this.props.handleCloseModal()
     }
 

--- a/src/components/asset/New/CloudStorage/Picker.test.js
+++ b/src/components/asset/New/CloudStorage/Picker.test.js
@@ -7,7 +7,7 @@ it('CloudStoragePicker renders without crashing', () => {
     const div = document.createElement('div')
     ReactDOM.render(
         <CloudStoragePicker
-            linkSetter={() => null}
+            fileSetter={() => null}
             handleCloseModal={() => null}
             storageProvider={{ loadFiles: () => { return [] } }}
             blobs={[]}

--- a/src/components/asset/New/index.js
+++ b/src/components/asset/New/index.js
@@ -7,7 +7,7 @@ import FormHelp from '../../atoms/Form/FormHelp'
 import CloudStorageLoader from '../../../containers/CloudStorageLoader'
 import Links from './Links/'
 
-const AssetNew = ({ handleSubmit, linkSetter, resetLinksForm }) => (
+const AssetNew = ({ handleSubmit, fileSetter, resetLinksForm }) => (
     <Form className="form" onSubmit={handleSubmit}>
 
         <FormInput label="Title" name="name" required component="input" type="text" help="The title of your asset." />
@@ -22,7 +22,7 @@ const AssetNew = ({ handleSubmit, linkSetter, resetLinksForm }) => (
             type="url"
             placeholder="e.g. https://url.com/dataset.zip"
             help="Add a URL pointing to your data set asset or select it from cloud storage providers."
-            additionalComponent={<CloudStorageLoader linkSetter={linkSetter} />}
+            additionalComponent={<CloudStorageLoader fileSetter={fileSetter} />}
         />
 
         <FormInput label="Price" name="price" required type="number" component="input" placeholder="0" help="Price of your asset in Ocean Tokens." />
@@ -77,7 +77,7 @@ const AssetNew = ({ handleSubmit, linkSetter, resetLinksForm }) => (
 
 AssetNew.propTypes = {
     handleSubmit: PropTypes.func.isRequired,
-    linkSetter: PropTypes.func.isRequired,
+    fileSetter: PropTypes.func.isRequired,
     resetLinksForm: PropTypes.func.isRequired
 }
 

--- a/src/containers/AssetNewLoader.js
+++ b/src/containers/AssetNewLoader.js
@@ -14,8 +14,8 @@ export default connect(
             dispatch(reset('newAsset'))
             dispatch(push('/'))
         },
-        linkSetter: (newValue) => {
-            dispatch(change('newAsset', 'contentUrls', newValue))
+        fileSetter: (newValue) => {
+            dispatch(change('newAsset', 'files', newValue))
         },
         resetLinksForm: () => {
             dispatch(change('newAsset', 'linkName', ''))

--- a/src/containers/CloudStoragePickerLoader.js
+++ b/src/containers/CloudStoragePickerLoader.js
@@ -5,8 +5,8 @@ import { change } from 'redux-form'
 export default connect(
     state => ({}),
     dispatch => ({
-        linkSetter: (newValue) => {
-            dispatch(change('newAsset', 'contentUrls', newValue))
+        fileSetter: (newValue) => {
+            dispatch(change('newAsset', 'files', newValue))
         }
     })
 )(CloudStoragePicker)

--- a/src/index.js
+++ b/src/index.js
@@ -90,8 +90,8 @@ ReactDOM.render(
                     try {
                         await window.ethereum.enable()
                         accounts = await web3.eth.getAccounts()
-                    } catch (e) {
-                        Logger.log('ethereum.enable() error:', e)
+                    } catch (error) {
+                        Logger.log('ethereum.enable() error:', error.message)
                         reject()
                     }
                 }

--- a/src/mock/assets.js
+++ b/src/mock/assets.js
@@ -5,18 +5,21 @@ const mockAssets = [
         'base': {
             'name': 'UK Weather information 2011',
             'description': 'Weather information of UK including temperature and humidity',
-            'size': '3.1gb',
-            'dateCreated': '2012-02-01T10:55:11+00:00',
+            'dateCreated': '2012-02-01T10:55:11Z',
             'author': 'Met Office',
             'type': 'dataset',
             'license': 'CC-BY',
             'copyrightHolder': 'Met Office',
-            'encoding': 'UTF-8',
-            'compression': 'zip',
-            'contentType': 'text/csv',
             'workExample': `stationId,latitude,longitude,datetime,temperature,humidity\n
                 423432fsd,51.509865,-0.118092,2011-01-01T10:55:11+00:00,7.2,68`,
-            'contentUrls': ['https://testocnfiles.blob.core.windows.net/testfiles/testzkp.zip'],
+            'files': [{
+                index: 0,
+                url: 'https://testocnfiles.blob.core.windows.net/testfiles/testzkp.zip',
+                'encoding': 'UTF-8',
+                'compression': 'zip',
+                'contentType': 'text/csv',
+                'size': '3.1gb'
+            }],
             'links': [
                 {
                     'name': 'Sample of Asset Data',
@@ -31,7 +34,7 @@ const mockAssets = [
             ],
             'inLanguage': 'en',
             'tags': ['weather', 'uk', '2011', 'temperature', 'humidity'],
-            'price': 10
+            'price': '100000000'
         },
         'curation': {
             'rating': 0.93,
@@ -52,18 +55,21 @@ const mockAssets = [
         'base': {
             'name': 'UK Weather information 2012',
             'description': 'Weather information of UK including temperature and humidity',
-            'size': '3.1gb',
-            'dateCreated': '2012-02-01T10:55:11+00:00',
+            'dateCreated': '2012-02-01T10:55:11Z',
             'author': 'Met Office',
             'type': 'dataset',
             'license': 'CC-BY',
             'copyrightHolder': 'Met Office',
-            'encoding': 'UTF-8',
-            'compression': 'zip',
-            'contentType': 'text/csv',
             'workExample': `stationId,latitude,longitude,datetime,temperature,humidity\n
                 423432fsd,51.509865,-0.118092,2011-01-01T10:55:11+00:00,7.2,68`,
-            'contentUrls': ['https://testocnfiles.blob.core.windows.net/testfiles/testzkp.zip'],
+            'files': [{
+                index: 0,
+                url: 'https://testocnfiles.blob.core.windows.net/testfiles/testzkp.zip',
+                'encoding': 'UTF-8',
+                'compression': 'zip',
+                'contentType': 'text/csv',
+                'size': '3.1gb'
+            }],
             'links': [
                 { 'sample1': 'http://data.ceda.ac.uk/badc/ukcp09/data/gridded-land-obs/gridded-land-obs-daily/' },
                 { 'sample2': 'http://data.ceda.ac.uk/badc/ukcp09/data/gridded-land-obs/gridded-land-obs-averages-25km/' },
@@ -92,18 +98,21 @@ const mockAssets = [
         'base': {
             'name': 'UK Weather information 2013',
             'description': 'Weather information of UK including temperature and humidity',
-            'size': '3.1gb',
-            'dateCreated': '2012-02-01T10:55:11+00:00',
+            'dateCreated': '2012-02-01T10:55:11Z',
             'author': 'Met Office',
             'type': 'dataset',
             'license': 'CC-BY',
             'copyrightHolder': 'Met Office',
-            'encoding': 'UTF-8',
-            'compression': 'zip',
-            'contentType': 'text/csv',
             'workExample': `stationId,latitude,longitude,datetime,temperature,humidity\n
                 423432fsd,51.509865,-0.118092,2011-01-01T10:55:11+00:00,7.2,68`,
-            'contentUrls': ['https://testocnfiles.blob.core.windows.net/testfiles/testzkp.zip'],
+            'files': [{
+                index: 0,
+                url: 'https://testocnfiles.blob.core.windows.net/testfiles/testzkp.zip',
+                'encoding': 'UTF-8',
+                'compression': 'zip',
+                'contentType': 'text/csv',
+                'size': '3.1gb'
+            }],
             'links': [
                 { 'sample1': 'http://data.ceda.ac.uk/badc/ukcp09/data/gridded-land-obs/gridded-land-obs-daily/' },
                 { 'sample2': 'http://data.ceda.ac.uk/badc/ukcp09/data/gridded-land-obs/gridded-land-obs-averages-25km/' },

--- a/src/models/asset.js
+++ b/src/models/asset.js
@@ -8,33 +8,23 @@ const AssetModel = {
         'name': null,
         'description': null,
         'dateCreated': null,
-        'size': null,
         'author': null,
         'type': '',
         'license': null,
         'copyrightHolder': null,
-        'encoding': null,
-        'compression': null,
-        'contentType': null,
-        'workExample': null,
         'files': [],
         'links': [{
             'name': null,
             'type': null,
             'url': null
         }],
-        'inLanguage': null,
         'tags': [],
-        'price': null
-    },
-    'curation': {
-        'rating': null,
-        'numVotes': null,
-        'schema': null
+        'price': '',
+        'workExample': '',
+        'inLanguage': ''
     },
     'additionalInformation': {
-        'updateFrequency': null,
-        'structuredMarkup': []
+        'updateFrequency': null
     }
 }
 

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -86,7 +86,7 @@ function registerValidSW(swUrl, config) {
             }
         })
         .catch(error => {
-            console.error('Error during service worker registration:', error)
+            console.error('Error during service worker registration:', error.message)
         })
 }
 


### PR DESCRIPTION
Reduce asset model to what is actually used in Pleuston, and updates for new metadata validations:

- `dateCreated` in correct date format
- `tags` as array
- tweaks to metadata display
- less verbose error logging

Publishing and metadata display tested against Aquarius `v0.2.8` running in Duero.

Closes #202